### PR TITLE
Implemented TempActor bound to a TempContainerActor

### DIFF
--- a/spinoff/actor/_actor.py
+++ b/spinoff/actor/_actor.py
@@ -996,9 +996,7 @@ class Cell(_BaseCell):
             pre_start = actor.pre_start
             args, kwargs = actor._Actor__startargs
             try:
-                self._ongoing = pre_start(*args, **kwargs)
-                yield self._ongoing
-                del self._ongoing
+                yield pre_start(*args, **kwargs)
             except Exception:
                 # dbg(u"☹")
                 raise CreateFailed("Actor failed to start", actor)

--- a/spinoff/actor/temp.py
+++ b/spinoff/actor/temp.py
@@ -1,0 +1,43 @@
+from twisted.internet.defer import Deferred
+
+from spinoff.actor.process import Process
+from spinoff.util.async import with_timeout, call_when_idle
+
+
+def TempActorFactory(context, timeout=None):
+    """Creates a class of temp actors all sharing a common containing actor
+    spawned from the `context` node, and (optionally) all sharing a common timeout.
+
+    >>> TempActor = TempActorFactory(our_node)
+    """
+
+    class _TempActor(object):
+        @classmethod
+        def make(cls, **kwargs):
+            kwargs.update(timeout=timeout)
+            return TempActor.make(context, **kwargs)
+
+    return _TempActor
+
+
+class TempActor(Process):
+    """Create a temporary actor which will fire a deferred when it receives its first reply.
+    The temporary actors will be stopped once they receive the first message (usually a reply)
+    or when the (optional) timeout occurs.
+
+    >>> temp, d = TempActor.make(timeout=2.0)
+    >>> target << ('message', temp)
+    >>> res = yield d
+    """
+
+    @classmethod
+    def make(cls, context, timeout=None):
+        d = Deferred()
+        return context.spawn(cls.using(d, timeout)), d
+
+    def run(self, d, timeout):
+        try:
+            msg = yield with_timeout(timeout, self.get())
+            call_when_idle(d.errback if isinstance(msg, BaseException) else d.callback, msg)
+        except Exception as e:
+            call_when_idle(d.errback, e)


### PR DESCRIPTION
This is my attempt to fix some usability problems I see in the current `TempActor` impl:
- each time you use TempActor you have to pass a reference to another actor where to spawn it from
- the temp actor doesn't stop when it gets it's reply
- it should be possible to timeout the temporary actor.

About the timeout issue: it would be straightforward to write with the current TempActor impl:

``` python
temp,d = TempActor.make(parent)
target << ('something', temp)
res = yield with_timeout(1.0, d)
```

This will work, but the temporary actor will stay alive forever and leak resources.
